### PR TITLE
Add support for SSL error handling

### DIFF
--- a/buckets/ssl_buckets.c
+++ b/buckets/ssl_buckets.c
@@ -348,7 +348,7 @@ static void log_ssl_error(serf_ssl_context_t *ctx)
         if (err && ctx->error_callback) {
             char ebuf[256];
             ERR_error_string_n(err, ebuf, sizeof(ebuf));
-            ctx->error_callback(ctx->error_baton, ebuf);
+            ctx->error_callback(ctx->error_baton, ctx->fatal_err, ebuf);
         }
 
     }
@@ -1682,15 +1682,7 @@ static int ssl_need_client_cert(SSL *ssl, X509 **cert, EVP_PKEY **pkey)
 
 error:
 
-    serf__log(LOGLVL_ERROR, LOGCOMP_SSL, __FILE__, ctx->config,
-              "OpenSSL cert error: %d %d\n", ERR_GET_LIB(err),
-              ERR_GET_REASON(err));
-
-    if (err && ctx->error_callback) {
-        char ebuf[256];
-        ERR_error_string_n(err, ebuf, sizeof(ebuf));
-        ctx->error_callback(ctx->error_baton, ebuf);
-    }
+    log_ssl_error(ctx);
 
     return 0;
 }
@@ -2135,8 +2127,9 @@ apr_status_t serf_ssl_add_crl_from_file(serf_ssl_context_t *ssl_ctx,
 
     result = X509_STORE_add_crl(store, crl);
     if (!result) {
+        ssl_ctx->fatal_err = status = SERF_ERROR_SSL_CERT_FAILED;
         log_ssl_error(ssl_ctx);
-        return SERF_ERROR_SSL_CERT_FAILED;
+        return status;
     }
 
     /* TODO: free crl when closing ssl session */

--- a/buckets/ssl_buckets.c
+++ b/buckets/ssl_buckets.c
@@ -1095,6 +1095,15 @@ static apr_status_t status_from_ssl_error(serf_ssl_context_t *ctx,
                 log_ssl_error(ctx);
             }
             break;
+
+        case SSL_ERROR_WANT_X509_LOOKUP:
+            /* The ssl_need_client_cert() function returned -1 because an
+             * error occurred inside that function. The error has already
+             * been handled, just return the fatal error.
+             */
+            status = ctx->fatal_err = SERF_ERROR_SSL_CERT_FAILED;
+            break;
+
         default:
             status = ctx->fatal_err = SERF_ERROR_SSL_COMM_FAILED;
             log_ssl_error(ctx);
@@ -1660,10 +1669,6 @@ static int ssl_need_client_cert(SSL *ssl, X509 **cert, EVP_PKEY **pkey)
         store = OSSL_STORE_open_ex(cert_uri, NULL, NULL, ui_method, ctx, NULL,
                                    NULL, NULL);
         if (!store) {
-            int err = ERR_get_error();
-            serf__log(LOGLVL_ERROR, LOGCOMP_SSL, __FILE__, ctx->config,
-                      "OpenSSL store error (%s): %d %d\n", cert_uri,
-                      ERR_GET_LIB(err), ERR_GET_REASON(err));
             break;
         }
 
@@ -1719,9 +1724,11 @@ static int ssl_need_client_cert(SSL *ssl, X509 **cert, EVP_PKEY **pkey)
             OSSL_STORE_INFO_free(info);
         }
 
-        /* FIXME: openssl error checking goes here */
-
         OSSL_STORE_close(store);
+
+        if (ERR_peek_error()) {
+            break;
+        }
 
         /* walk the leaf certificates, choose the best one */
 
@@ -1788,6 +1795,12 @@ static int ssl_need_client_cert(SSL *ssl, X509 **cert, EVP_PKEY **pkey)
     sk_EVP_PKEY_pop_free(keys, EVP_PKEY_free);
     X509_STORE_free(requests);
     UI_destroy_method(ui_method);
+
+    if (ERR_peek_error()) {
+        log_ssl_error(ctx);
+
+        return -1;
+    }
 
     /* we settled on a cert and key, cache it for later */
 

--- a/buckets/ssl_buckets.c
+++ b/buckets/ssl_buckets.c
@@ -1669,6 +1669,14 @@ static int ssl_need_client_cert(SSL *ssl, X509 **cert, EVP_PKEY **pkey)
         store = OSSL_STORE_open_ex(cert_uri, NULL, NULL, ui_method, ctx, NULL,
                                    NULL, NULL);
         if (!store) {
+
+            if (ctx->error_callback) {
+                char ebuf[1024];
+                ctx->fatal_err = SERF_ERROR_SSL_CERT_FAILED;
+                apr_snprintf(ebuf, sizeof(ebuf), "could not open URI: %s", cert_uri);
+                ctx->error_callback(ctx->error_baton, ctx->fatal_err, ebuf);
+            }
+
             break;
         }
 
@@ -1678,6 +1686,14 @@ static int ssl_need_client_cert(SSL *ssl, X509 **cert, EVP_PKEY **pkey)
             info = OSSL_STORE_load(store);
 
             if (!info) {
+
+                if (ctx->error_callback) {
+                    char ebuf[1024];
+                    ctx->fatal_err = SERF_ERROR_SSL_CERT_FAILED;
+                    apr_snprintf(ebuf, sizeof(ebuf), "could not read URI: %s", cert_uri);
+                    ctx->error_callback(ctx->error_baton, ctx->fatal_err, ebuf);
+                }
+
                 break;
             }
 
@@ -1862,7 +1878,9 @@ static int ssl_need_client_cert(SSL *ssl, X509 **cert, EVP_PKEY **pkey)
 
         if (status) {
             if (ctx->error_callback) {
-                char ebuf[256];
+                char ebuf[1024];
+                apr_snprintf(ebuf, sizeof(ebuf), "could not open PKCS12: %s", cert_path);
+                ctx->error_callback(ctx->error_baton, ctx->fatal_err, ebuf);
                 apr_strerror(status, ebuf, sizeof(ebuf));
                 ctx->error_callback(ctx->error_baton, ctx->fatal_err, ebuf);
             }
@@ -1944,6 +1962,14 @@ static int ssl_need_client_cert(SSL *ssl, X509 **cert, EVP_PKEY **pkey)
                             return 1;
                         }
                         else {
+
+                            if (ctx->error_callback) {
+                                char ebuf[1024];
+                                ctx->fatal_err = SERF_ERROR_SSL_CERT_FAILED;
+                                apr_snprintf(ebuf, sizeof(ebuf), "could not parse PKCS12: %s", cert_path);
+                                ctx->error_callback(ctx->error_baton, ctx->fatal_err, ebuf);
+                            }
+
                             log_ssl_error(ctx);
                             return -1;
                         }
@@ -1952,12 +1978,26 @@ static int ssl_need_client_cert(SSL *ssl, X509 **cert, EVP_PKEY **pkey)
                 PKCS12_free(p12);
                 bio_meth_free(biom);
 
+                if (ctx->error_callback) {
+                    char ebuf[1024];
+                    ctx->fatal_err = SERF_ERROR_SSL_CERT_FAILED;
+                    apr_snprintf(ebuf, sizeof(ebuf), "PKCS12 needs a password: %s", cert_path);
+                    ctx->error_callback(ctx->error_baton, ctx->fatal_err, ebuf);
+                }
+
                 log_ssl_error(ctx);
                 return -1;
             }
             else {
                 PKCS12_free(p12);
                 bio_meth_free(biom);
+
+                if (ctx->error_callback) {
+                    char ebuf[1024];
+                    ctx->fatal_err = SERF_ERROR_SSL_CERT_FAILED;
+                    apr_snprintf(ebuf, sizeof(ebuf), "could not parse PKCS12: %s", cert_path);
+                    ctx->error_callback(ctx->error_baton, ctx->fatal_err, ebuf);
+                }
 
                 log_ssl_error(ctx);
                 return -1;

--- a/buckets/ssl_buckets.c
+++ b/buckets/ssl_buckets.c
@@ -342,9 +342,6 @@ static void log_ssl_error(serf_ssl_context_t *ctx)
 
     while ((err = ERR_get_error())) {
 
-        serf__log(LOGLVL_ERROR, LOGCOMP_SSL, __FILE__, ctx->config,
-                  "SSL Error: %s\n", ERR_error_string(err, NULL));
-
         if (err && ctx->error_callback) {
             char ebuf[256];
             ERR_error_string_n(err, ebuf, sizeof(ebuf));

--- a/buckets/ssl_buckets.c
+++ b/buckets/ssl_buckets.c
@@ -187,6 +187,10 @@ struct serf_ssl_context_t {
     X509 *cached_cert;
     EVP_PKEY *cached_cert_pw;
 
+    /* Error callback */
+    serf_ssl_error_cb_t error_callback;
+    void *error_userdata;
+
     apr_status_t pending_err;
 
     /* Status of a fatal error, returned on subsequent encrypt or decrypt
@@ -334,10 +338,20 @@ detect_renegotiate(const SSL *s, int where, int ret)
 
 static void log_ssl_error(serf_ssl_context_t *ctx)
 {
-    unsigned long e = ERR_get_error();
-    serf__log(LOGLVL_ERROR, LOGCOMP_SSL, __FILE__, ctx->config,
-              "SSL Error: %s\n", ERR_error_string(e, NULL));
+    unsigned long err;
 
+    while ((err = ERR_get_error())) {
+
+        serf__log(LOGLVL_ERROR, LOGCOMP_SSL, __FILE__, ctx->config,
+                  "SSL Error: %s\n", ERR_error_string(err, NULL));
+
+        if (err && ctx->error_callback) {
+            char ebuf[256];
+            ERR_error_string_n(err, ebuf, sizeof(ebuf));
+            ctx->error_callback(ctx->error_userdata, ebuf);
+        }
+
+    }
 }
 
 static void bio_set_data(BIO *bio, void *data)
@@ -1056,15 +1070,6 @@ static apr_status_t status_from_ssl_error(serf_ssl_context_t *ctx,
                 status = ctx->pending_err;
                 ctx->pending_err = APR_SUCCESS;
             } else {
-                /*unsigned long l = ERR_peek_error();
-                int lib = ERR_GET_LIB(l);
-                int reason = ERR_GET_REASON(l);*/
-
-                /* ### Detect more specific errors?
-                  When lib is ERR_LIB_SSL, then reason is one of the
-                  many SSL_R_XXXX reasons in ssl.h
-                */
-
                 if (SSL_in_init(ctx->ssl))
                     ctx->fatal_err = SERF_ERROR_SSL_SETUP_FAILED;
                 else
@@ -1536,6 +1541,7 @@ static apr_status_t init_ssl_libraries(void)
 static int ssl_need_client_cert(SSL *ssl, X509 **cert, EVP_PKEY **pkey)
 {
     serf_ssl_context_t *ctx = SSL_get_app_data(ssl);
+    unsigned long err = 0;
     apr_status_t status;
 
     serf__log(LOGLVL_DEBUG, LOGCOMP_SSL, __FILE__, ctx->config,
@@ -1606,7 +1612,7 @@ static int ssl_need_client_cert(SSL *ssl, X509 **cert, EVP_PKEY **pkey)
             return 1;
         }
         else {
-            int err = ERR_get_error();
+            err = ERR_get_error();
             ERR_clear_error();
             if (ERR_GET_LIB(err) == ERR_LIB_PKCS12 &&
                 ERR_GET_REASON(err) == PKCS12_R_MAC_VERIFY_FAILURE) {
@@ -1652,20 +1658,38 @@ static int ssl_need_client_cert(SSL *ssl, X509 **cert, EVP_PKEY **pkey)
                             }
                             return 1;
                         }
+                        else {
+                            err = ERR_get_error();
+                            ERR_clear_error();
+
+                            goto error;
+                        }
                     }
                 }
                 PKCS12_free(p12);
                 bio_meth_free(biom);
-                return 0;
+
+                goto error;
             }
             else {
-                serf__log(LOGLVL_ERROR, LOGCOMP_SSL, __FILE__, ctx->config,
-                          "OpenSSL cert error: %d %d\n", ERR_GET_LIB(err),
-                          ERR_GET_REASON(err));
                 PKCS12_free(p12);
                 bio_meth_free(biom);
+
+                goto error;
             }
         }
+    }
+
+error:
+
+    serf__log(LOGLVL_ERROR, LOGCOMP_SSL, __FILE__, ctx->config,
+              "OpenSSL cert error: %d %d\n", ERR_GET_LIB(err),
+              ERR_GET_REASON(err));
+
+    if (err && ctx->error_callback) {
+        char ebuf[256];
+        ERR_error_string_n(err, ebuf, sizeof(ebuf));
+        ctx->error_callback(ctx->error_userdata, ebuf);
     }
 
     return 0;
@@ -1722,6 +1746,15 @@ void serf_ssl_server_cert_chain_callback_set(
     context->server_cert_callback = cert_callback;
     context->server_cert_chain_callback = cert_chain_callback;
     context->server_cert_userdata = data;
+}
+
+void serf_ssl_error_cb_set(
+    serf_ssl_context_t *context,
+    serf_ssl_error_cb_t callback,
+    void *data)
+{
+    context->error_callback = callback;
+    context->error_userdata = data;
 }
 
 static int ssl_new_session(SSL *ssl, SSL_SESSION *session)
@@ -1787,6 +1820,9 @@ static serf_ssl_context_t *ssl_init_context(serf_bucket_alloc_t *allocator)
     ssl_ctx->handshake_finished = FALSE;
     ssl_ctx->protocol_callback = NULL;
     ssl_ctx->protocol_userdata = NULL;
+
+    ssl_ctx->error_callback = NULL;
+    ssl_ctx->error_userdata = NULL;
 
     SSL_CTX_set_verify(ssl_ctx->ctx, SSL_VERIFY_PEER,
                        validate_server_certificate);

--- a/buckets/ssl_buckets.c
+++ b/buckets/ssl_buckets.c
@@ -1576,9 +1576,13 @@ static int ssl_need_client_cert(SSL *ssl, X509 **cert, EVP_PKEY **pkey)
         status = apr_file_open(&cert_file, cert_path, APR_READ, APR_OS_DEFAULT,
                                ctx->pool);
 
-        /* TODO: this will hang indefintely when the file can't be found. */
         if (status) {
-            continue;
+            if (ctx->error_callback) {
+                char ebuf[256];
+                apr_strerror(status, ebuf, sizeof(ebuf));
+                ctx->error_callback(ctx->error_baton, ctx->fatal_err, ebuf);
+            }
+            break;
         }
 
         biom = bio_meth_file_new();

--- a/buckets/ssl_buckets.c
+++ b/buckets/ssl_buckets.c
@@ -1656,30 +1656,26 @@ static int ssl_need_client_cert(SSL *ssl, X509 **cert, EVP_PKEY **pkey)
                             return 1;
                         }
                         else {
-                            err = ERR_get_error();
-                            ERR_clear_error();
-
-                            goto error;
+                            log_ssl_error(ctx);
+                            break;
                         }
                     }
                 }
                 PKCS12_free(p12);
                 bio_meth_free(biom);
 
-                goto error;
+                log_ssl_error(ctx);
+                break;
             }
             else {
                 PKCS12_free(p12);
                 bio_meth_free(biom);
 
-                goto error;
+                log_ssl_error(ctx);
+                break;
             }
         }
     }
-
-error:
-
-    log_ssl_error(ctx);
 
     return 0;
 }

--- a/buckets/ssl_buckets.c
+++ b/buckets/ssl_buckets.c
@@ -1866,7 +1866,7 @@ static int ssl_need_client_cert(SSL *ssl, X509 **cert, EVP_PKEY **pkey)
                 apr_strerror(status, ebuf, sizeof(ebuf));
                 ctx->error_callback(ctx->error_baton, ctx->fatal_err, ebuf);
             }
-            break;
+            return -1;
         }
 
         biom = bio_meth_file_new();
@@ -1945,7 +1945,7 @@ static int ssl_need_client_cert(SSL *ssl, X509 **cert, EVP_PKEY **pkey)
                         }
                         else {
                             log_ssl_error(ctx);
-                            break;
+                            return -1;
                         }
                     }
                 }
@@ -1953,14 +1953,14 @@ static int ssl_need_client_cert(SSL *ssl, X509 **cert, EVP_PKEY **pkey)
                 bio_meth_free(biom);
 
                 log_ssl_error(ctx);
-                break;
+                return -1;
             }
             else {
                 PKCS12_free(p12);
                 bio_meth_free(biom);
 
                 log_ssl_error(ctx);
-                break;
+                return -1;
             }
         }
     }

--- a/buckets/ssl_buckets.c
+++ b/buckets/ssl_buckets.c
@@ -189,7 +189,7 @@ struct serf_ssl_context_t {
 
     /* Error callback */
     serf_ssl_error_cb_t error_callback;
-    void *error_userdata;
+    void *error_baton;
 
     apr_status_t pending_err;
 
@@ -348,7 +348,7 @@ static void log_ssl_error(serf_ssl_context_t *ctx)
         if (err && ctx->error_callback) {
             char ebuf[256];
             ERR_error_string_n(err, ebuf, sizeof(ebuf));
-            ctx->error_callback(ctx->error_userdata, ebuf);
+            ctx->error_callback(ctx->error_baton, ebuf);
         }
 
     }
@@ -1689,7 +1689,7 @@ error:
     if (err && ctx->error_callback) {
         char ebuf[256];
         ERR_error_string_n(err, ebuf, sizeof(ebuf));
-        ctx->error_callback(ctx->error_userdata, ebuf);
+        ctx->error_callback(ctx->error_baton, ebuf);
     }
 
     return 0;
@@ -1751,10 +1751,10 @@ void serf_ssl_server_cert_chain_callback_set(
 void serf_ssl_error_cb_set(
     serf_ssl_context_t *context,
     serf_ssl_error_cb_t callback,
-    void *data)
+    void *baton)
 {
     context->error_callback = callback;
-    context->error_userdata = data;
+    context->error_baton = baton;
 }
 
 static int ssl_new_session(SSL *ssl, SSL_SESSION *session)
@@ -1822,7 +1822,7 @@ static serf_ssl_context_t *ssl_init_context(serf_bucket_alloc_t *allocator)
     ssl_ctx->protocol_userdata = NULL;
 
     ssl_ctx->error_callback = NULL;
-    ssl_ctx->error_userdata = NULL;
+    ssl_ctx->error_baton = NULL;
 
     SSL_CTX_set_verify(ssl_ctx->ctx, SSL_VERIFY_PEER,
                        validate_server_certificate);

--- a/serf_bucket_types.h
+++ b/serf_bucket_types.h
@@ -648,6 +648,22 @@ void serf_ssl_server_cert_chain_callback_set(
     void *data);
 
 /**
+ * Callback type for detailed TLS error strings.
+ */
+typedef apr_status_t (*serf_ssl_error_cb_t)(
+    void *data,
+    const char *message);
+
+/**
+ * Set a callback to return any detailed certificate error from the underlying
+ * cryptographic library..
+ */
+void serf_ssl_error_cb_set(
+    serf_ssl_context_t *context,
+    serf_ssl_error_cb_t callback,
+    void *data);
+
+/**
  * Use the default root CA certificates as included with the OpenSSL library.
  */
 apr_status_t serf_ssl_use_default_certificates(

--- a/serf_bucket_types.h
+++ b/serf_bucket_types.h
@@ -651,7 +651,7 @@ void serf_ssl_server_cert_chain_callback_set(
  * Callback type for detailed TLS error strings.
  */
 typedef apr_status_t (*serf_ssl_error_cb_t)(
-    void *data,
+    void *baton,
     const char *message);
 
 /**
@@ -661,7 +661,7 @@ typedef apr_status_t (*serf_ssl_error_cb_t)(
 void serf_ssl_error_cb_set(
     serf_ssl_context_t *context,
     serf_ssl_error_cb_t callback,
-    void *data);
+    void *baton);
 
 /**
  * Use the default root CA certificates as included with the OpenSSL library.

--- a/serf_bucket_types.h
+++ b/serf_bucket_types.h
@@ -659,6 +659,7 @@ void serf_ssl_server_cert_chain_callback_set(
  */
 typedef apr_status_t (*serf_ssl_error_cb_t)(
     void *baton,
+    apr_status_t status,
     const char *message);
 
 /**

--- a/serf_bucket_types.h
+++ b/serf_bucket_types.h
@@ -648,7 +648,14 @@ void serf_ssl_server_cert_chain_callback_set(
     void *data);
 
 /**
- * Callback type for detailed TLS error strings.
+ * Callback type for detailed TLS error strings. This callback will be fired
+ * every time the underlying crypto library encounters an error. The message
+ * lasts only as long as the callback, if the caller wants to set aside the
+ * message for later use, a copy must be made.
+ *
+ * It is possible that for a given error multiple strings will be returned
+ * in multiple callbacks. The caller may choose to handle all strings, or
+ * may choose to ignore all strings but the last most detailed one.
  */
 typedef apr_status_t (*serf_ssl_error_cb_t)(
     void *baton,
@@ -656,7 +663,10 @@ typedef apr_status_t (*serf_ssl_error_cb_t)(
 
 /**
  * Set a callback to return any detailed certificate error from the underlying
- * cryptographic library..
+ * cryptographic library.
+ *
+ * The callback is associated with the context, however the choice of baton
+ * will depend on the needs of the caller.
  */
 void serf_ssl_error_cb_set(
     serf_ssl_context_t *context,


### PR DESCRIPTION
- Allow the registration of an optional callback using serf_ssl_error_cb_set().

- If the callback is registered, return a fixed string describing the error as created by the underlying crypto library.

Example:

```
[minfrin@rocky9 subversion]$ svn info https://svn.example.com/svn/example/core/
svn: E170013: Unable to connect to a repository at URL 'https://svn.example.com/svn/example/core'
svn: E120170: TLS: error:0308010C:digital envelope routines::unsupported
svn: E120170: TLS: could not parse PKCS12: /home/minfrin/.my-cert.p12
```
